### PR TITLE
Added list of blend modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,33 @@ openFrameworks Photoshop blending math with GLSL.
 
 refs. http://mouaif.wordpress.com/2009/01/05/photoshop-math-with-glsl-shaders/
 
-### usage ###
-please check testApp.h/.cpp in ofxPSBlendExample
+## Usage ##
+Please check testApp.h/.cpp in ofxPSBlendExample
  
+## List of supported blend modes ##
+* 0: Normal
+* 1: Multiply
+* 2: Average
+* 3: Add
+* 4: Substract
+* 5: Difference
+* 6: Negation
+* 7: Exclusion
+* 8: Screen
+* 9: Overlay
+* 10: SoftLight
+* 11: HardLight
+* 12: ColorDodge
+* 13: ColorBurn
+* 14: LinearLight
+* 15: VividLight
+* 16: PinLight
+* 17: HardMix
+* 18: Reflect
+* 19: Glow
+* 20: Phoenix
+* 21: Hue
+* 22: Saturation
+* 23: Color
+* 24: Luminosity
+  


### PR DESCRIPTION
I thought it would be useful to include a list of the available blend modes (with the numbering) in the README, so new users did not have to look these up in the source code.